### PR TITLE
meta-java: use the updated repository

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -36,7 +36,7 @@
   <!-- <project name="meta-eca" remote="yocto" path="meta-eca"/> -->
   <project name="meta-security" remote="yocto" path="meta-security"/>
 
-  <project name="woglinde/meta-java" remote="github" path="meta-java"/>
+  <project name="meta-java" remote="yocto" path="meta-java"/>
   <project name="meta-qt5/meta-qt5" remote="github" path="meta-qt5"/>
   <project name="OSSystems/meta-browser" remote="github" path="meta-browser"/>
   <project name="joaohf/meta-erlang" remote="github" path="meta-erlang"/>


### PR DESCRIPTION
meta-java was moved from github to http://git.yoctoproject.org.
Based on that, update default.xml.

Signed-off-by: Maxin B. John maxin.john@intel.com
